### PR TITLE
Performance: don't use VM when not needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,11 @@ function compile (template, defaultContext, ops) {
   if (typeof template !== 'string') {
     throw new TypeError('Template must be a string')
   }
+
+  if (!template.includes('${')) {
+    return () => template
+  }
+
   const options = Object.assign({timeout: 500}, ops)
   const script = new vm.Script(escape(template))
   return (context) => {

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ function escape (template) {
 
 function compile (template, defaultContext, ops) {
   if (typeof template !== 'string') {
-    throw new Error('Template must be a string')
+    throw new TypeError('Template must be a string')
   }
   const options = Object.assign({timeout: 500}, ops)
   const script = new vm.Script(escape(template))

--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
   "engines": {
     "node": ">=4.0.0"
   },
+  "files": [
+    "index.js"
+  ],
   "devDependencies": {
     "ava": "^0.22.0",
     "eslint": "^4.4.1",


### PR DESCRIPTION
As this package assumes \`strings\` in JS ${ is needed to do logic.
When it is not included, logic is not needed -> no vm needed.

Within my projects I have many templates which do not use execution but always take time. As they can be used often this should take as little time as possible.

In order to check I used this for loop:
```js
console.time('time')
for (let i = 0; i < 1000; i++) {
  compile('something lame without execution')
}
console.timeEnd('time')
```

With the optimisation I get this result: `time: 1.275ms`
Without the optimisation I get `time: 3.614ms`
While using this within telegraf-i18n this change alone improves the startup time of the bot (which recreates notifications in the users languages) from about 9s to 2.4s.

I also added the package.json files section and changed an Error to TypeError but as these changes are very small I don't think another PR is worth it.