### PR TITLE
Fix "Failed to compile template" error

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ function compile (template, defaultContext, ops) {
     try {
       return script.runInNewContext(Object.assign({}, defaultContext, context), options)
     } catch (err) {
-      throw new Error('Failed to compile template', err)
+      throw new Error('Failed to compile template', {cause: err})
     }
   }
 }


### PR DESCRIPTION
This line did not convey the reason for the error (err), which made it harder to figure out what was wrong.